### PR TITLE
JavaScriptRuntime Dispose fix.

### DIFF
--- a/source/ChakraCore.NET.Core/API/JavaScriptRuntime.cs
+++ b/source/ChakraCore.NET.Core/API/JavaScriptRuntime.cs
@@ -140,6 +140,7 @@
         {
             if (IsValid)
             {
+                Native.ThrowIfError(Native.JsSetCurrentContext(JavaScriptContext.Invalid));
                 Native.ThrowIfError(Native.JsDisposeRuntime(this));
             }
 


### PR DESCRIPTION
It caused "Runtime is in use" exception, when running script was terminated and then disposed  JavaScriptRuntime.

Reference: https://github.com/Microsoft/ChakraCore/wiki/Embedding-ChakraCore