### PR TITLE
Fix access violation in ContextService.RunModule

### DIFF
--- a/source/ChakraCore.NET.Core/Service/ContextService.cs
+++ b/source/ChakraCore.NET.Core/Service/ContextService.cs
@@ -98,7 +98,7 @@ namespace ChakraCore.NET
                         {
                             contextSwitch.With(item.parse);
                         }
-                        
+                        GC.KeepAlive(item);
                     }
                     catch(OperationCanceledException)
                     {
@@ -109,7 +109,7 @@ namespace ChakraCore.NET
                         moduleLoadException = ex;
                         moduleReadyEvent.Set();
                     }
-                    
+
                 }
             },ContextShutdownCTS.Token);
         }


### PR DESCRIPTION
The local variable `item` is eligible for garbage collection after the `Action` in field `item.parse` has been accessed and put on the stack, but before the call to `contextSwitch.With` is actually executed. After this point `item` is not referenced in the method anymore. That means that the delegates referenced in `item.items` can be collected before the call to `item.parse` returns, which can result in an access violation.

This adds a call to `GC.KeepAlive` to make sure `item` is not prematurely collected.